### PR TITLE
Only enable slider behaviour if there are at least two panes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Only enable slider behaviour if there are at least two panes.
+  Otherwise display the single slider pane without the slider controls.
+  [Julian Infanger]
+
 - Do no use RelationChoice (z3c.relationfield) if you don't use Relations.
   I guess we should use plone.app.relationfield.
   The old implementation did not make any sense. Storing string value in a

--- a/ftw/slider/browser/resources/slider.js
+++ b/ftw/slider/browser/resources/slider.js
@@ -11,7 +11,7 @@ jQuery(function($) {
     adjust_slider_size();
   });
 
-  var root = $("#slider-wrapper").scrollable({
+  var root = $("#slider-wrapper.enabled").scrollable({
     circular: true,
     touch: false,
     speed: 600

--- a/ftw/slider/browser/slider.pt
+++ b/ftw/slider/browser/slider.pt
@@ -1,13 +1,17 @@
 <tal:slider define="panes view/panes;
+                    slider_enabled python:len(panes) > 1;
                     portal context/@@plone_portal_state/portal;">
   <div id="slider-wrapper"
+       tal:attributes="class python:slider_enabled and 'enabled' or None"
        tal:condition="panes">
     <div id="slider-panes">
       <div tal:repeat="pane panes"
            class="sliderPane">
 
-        <a class="prev">&nbsp;</a>
-        <a class="next">&nbsp;</a>
+        <tal:slider_enabled condition="slider_enabled">
+          <a class="prev">&nbsp;</a>
+          <a class="next">&nbsp;</a>
+        </tal:slider_enabled>
 
         <a tal:omit-tag="not:pane/link"
            tal:attributes="href string:${portal/absolute_url}${pane/link}">
@@ -26,7 +30,7 @@
     </div>
 
   </div>
-  <div id="slider-navi"></div>
+  <div id="slider-navi" tal:condition="slider_enabled"></div>
 
   <div class="visualClear"><!-- --></div>
 


### PR DESCRIPTION
@4teamwork/coders @maethu
Could someone take a look please? :eyes: 

If there is just one SliderPane there is no need to enable the slider behaviour.
![slider](https://f.cloud.github.com/assets/157533/1866777/0b66feae-783d-11e3-8302-e9b7311c1b9a.png)
