### PR TITLE
Fixed z-index of prev and next buttons in ie9

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed ie9 slider buttons (appended z-index to bring the button to the foreground)
 
 
 2.1.2 (2014-09-30)

--- a/ftw/slider/browser/resources/slider.css
+++ b/ftw/slider/browser/resources/slider.css
@@ -41,6 +41,9 @@
 /* @end */
 
 /* @group prev next navi */
+.slick-list {
+  z-index: 1;
+}
 
 .slick-prev, .slick-next {
   display: none !important;
@@ -58,6 +61,7 @@
   border: none;
   background-color: #FFF;
   background-color: rgba(255,255,255,0.5);
+  z-index: 2;
 }
 .slick-prev {
   left: 0;


### PR DESCRIPTION
In ie9 the prev and next buttons for sliding the images were not clickable due to z-index fails. Appended z-index attributes to fix it.
