### PR TITLE
Do not hide the slick arrows by default.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
+- Don't hide the slick arrows.
+  [mbaechtold]
+
 - Add Plone 4.3.5 support.
   [jone]
 

--- a/ftw/slider/browser/resources/slider.css
+++ b/ftw/slider/browser/resources/slider.css
@@ -46,7 +46,6 @@
 }
 
 .slick-prev, .slick-next {
-  display: none !important;
   line-height: 0;
   font-size: 0;
   cursor: pointer;


### PR DESCRIPTION
We suppose this has initially been implemented so the arrows could be display when hovering the mouse over the image (in a custom plonetheme). Please update your theme if it depends on this behaviour.