### PR TITLE
No longer apply IDexterityTranslatable behavior automatically.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
+- No longer apply IDexterityTranslatable behavior automatically.
+  [mathias.leimgruber]
+
 - Don't hide the slick arrows.
   [mbaechtold]
 

--- a/ftw/slider/profiles/default/types/ftw.slider.Container.xml
+++ b/ftw/slider/profiles/default/types/ftw.slider.Container.xml
@@ -30,8 +30,6 @@
     <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
     <element value="plone.app.content.interfaces.INameFromTitle" />
     <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
-    <element zcml:condition="installed plone.multilingualbehavior"
-             value="plone.multilingualbehavior.interfaces.IDexterityTranslatable" />
   </property>
 
   <!-- View information -->

--- a/ftw/slider/profiles/default/types/ftw.slider.Pane.xml
+++ b/ftw/slider/profiles/default/types/ftw.slider.Pane.xml
@@ -28,8 +28,6 @@
   <property name="behaviors">
     <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
     <element value="plone.app.content.interfaces.INameFromTitle" />
-    <element zcml:condition="installed plone.multilingualbehavior"
-             value="plone.multilingualbehavior.interfaces.IDexterityTranslatable" />
   </property>
 
   <!-- View information -->


### PR DESCRIPTION
- First zcml:condition only works in zcml files, not in xml.
- Second the behavior should be applied by a policy, not by default.
  Only a few will have plone.app.multilingual installed.