### PR TITLE
Slider throws error on initialize in ie10.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,9 +5,12 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
+- Fix initialisation error for slider in IE10
+  [Kevin Bieri]
+
 - Link the slider pane to an external url.
   [mbaechtold]
-  
+
 - Implement play and pause button.
   [Kevin Bieri]
 

--- a/ftw/slider/browser/resources/slider.js
+++ b/ftw/slider/browser/resources/slider.js
@@ -57,7 +57,7 @@
   $(function() {
     var ftwSliderInit = function(){
       $(".sliderWrapper").each(function() {
-        var slider = new Slider($(".sliderPanes", this), JSON.parse(this.dataset.settings));
+        var slider = new Slider($(".sliderPanes", this), $(this).data("settings"));
       });
     };
     ftwSliderInit();


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/194

Due to
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset#Browser_compatibility
ie 10 does not support the dataset API. So use jQuery's data method for
accesssing the settings data attribute.