### PR TITLE
Enable IReferenceable on all types.

### DIFF
--- a/ftw/slider/profiles/default/types/ftw.slider.Container.xml
+++ b/ftw/slider/profiles/default/types/ftw.slider.Container.xml
@@ -30,6 +30,7 @@
     <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
     <element value="plone.app.content.interfaces.INameFromTitle" />
     <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
+    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     <element zcml:condition="installed plone.multilingualbehavior"
              value="plone.multilingualbehavior.interfaces.IDexterityTranslatable" />
   </property>

--- a/ftw/slider/profiles/default/types/ftw.slider.Pane.xml
+++ b/ftw/slider/profiles/default/types/ftw.slider.Pane.xml
@@ -28,6 +28,7 @@
   <property name="behaviors">
     <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
     <element value="plone.app.content.interfaces.INameFromTitle" />
+    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     <element zcml:condition="installed plone.multilingualbehavior"
              value="plone.multilingualbehavior.interfaces.IDexterityTranslatable" />
   </property>


### PR DESCRIPTION
The IReferenceable behavior adds the objects to the reference catalog.
We need this in order to lookup objects by UUID.