### PR TITLE
Use UID-based scaling urls in order to have caching.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
+- Use UID-based scaling urls in order to have caching.
+  [jone]
+
 - Mark image field as primary field.
   [jone]
 

--- a/ftw/slider/browser/slider.pt
+++ b/ftw/slider/browser/slider.pt
@@ -12,9 +12,10 @@
                               link python: internal_link and pane.link or pane.external_url;">
           <a tal:omit-tag="not:link"
              tal:attributes="href link">
-            <div class="sliderImage"
-                 tal:content="structure pane/@@images/image"
-                 />
+              <div class="sliderImage"
+                   tal:define="images pane/@@images"
+                   tal:content="structure python:images.tag()"
+                   />
             <div class="sliderText"
                  tal:condition="pane/text">
               <p tal:condition="pane/title" tal:content="pane/title"


### PR DESCRIPTION
Be aware that scales caching requires plone.namedfile >= 2.0.8 and UID
based urls. plone.app.caching must be configured accordingly.