### PR TITLE
Slider action buttons have only default labels.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
+- Add translations for play, pause, next and previous buttons.
+  [Kevin Bieri, jone]
+
 - Add slick_config field to container schema
   [elioschmutz]
 

--- a/ftw/slider/browser/resources/slider.js
+++ b/ftw/slider/browser/resources/slider.js
@@ -9,23 +9,34 @@
     config = $.extend({
       canPlay: false,
       canPause: false,
-      slidesToShow: 1
+      slidesToShow: 1,
+      labels: {}
     }, config);
 
-    var buttonTemplate = '<button type="button" class="slick-{{:action}}" aria-label="{{:action}}">{{:action}}</button>';
+    var buttonTemplate = '<button type="button" class="slick-{{:action}}" aria-label="{{:action}}"></button>';
 
     var play = function() { element.slick("slickPlay"); };
 
     var pause = function() { element.slick("slickPause"); };
 
-    var buildButton = function(name, handler) {
-      var button = $(buttonTemplate.replace(/{{:action}}/g, name));
-      return button.on("click", handler);
+    var buildButton = function(name, label, handler) {
+      var button = $(buttonTemplate.replace(/{{:action}}/g, name)).text(label);
+      if(handler) {
+        button.on("click", handler);
+      }
+      return button;
     };
 
-    var addPlayButton = function() { element.append(buildButton("play", play)); };
+    var addPlayButton = function() { element.append(buildButton("play", config.labels.play, play)); };
 
-    var addPauseButton = function() { element.append(buildButton("pause", pause)); };
+    var addPauseButton = function() { element.append(buildButton("pause", config.labels.pause, pause)); };
+
+    var prevButton = buildButton("prev", config.labels.prev);
+
+    var nextButton = buildButton("next", config.labels.next);
+
+    config.prevArrow = prevButton.prop("outerHTML");
+    config.nextArrow = nextButton.prop("outerHTML");
 
     var destroy = function() {
       element.slick("destroy");
@@ -78,6 +89,7 @@
       }
 
       element.on("breakpoint", function(event, slick, breakpoint) { update(null, slick.breakpointSettings[breakpoint]); });
+
     };
 
     var update = function(updatedElement, updatedConfig) {

--- a/ftw/slider/browser/slider.py
+++ b/ftw/slider/browser/slider.py
@@ -2,6 +2,7 @@ from ftw.slider import _
 from plone.dexterity.browser.add import DefaultAddForm, DefaultAddView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
+from zope.i18n import translate
 from zope.publisher.browser import BrowserView
 import json
 
@@ -16,12 +17,27 @@ class SliderView(BrowserView):
     def panes(self):
         return self.context.getFolderContents(full_objects=True)
 
+    def extend_translations(self, config):
+        translations = {
+            'play': translate(_(u'label_slider_play', default=u'Play'),
+                              context=self.request),
+            'pause': translate(_(u'label_slider_pause', default=u'Pause'),
+                               context=self.request),
+            'next': translate(_(u'label_slider_next', default=u'Next'),
+                              context=self.request),
+            'prev': translate(_(u'label_slider_prev', default=u'Previous'),
+                              context=self.request),
+        }
+        config['labels'] = translations
+        return config
+
     def get_slick_config(self):
         # The config value may contain unwanted new lines. Let's remove them
         # by loading and dumping as json.
         if not self.context.slick_config:
             return '{}'
         config = json.loads(self.context.slick_config)
+        config = self.extend_translations(config)
         return json.dumps(config)
 
 

--- a/ftw/slider/locales/de/LC_MESSAGES/ftw.slider.po
+++ b/ftw/slider/locales/de/LC_MESSAGES/ftw.slider.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-02 07:57+0000\n"
+"POT-Creation-Date: 2015-09-28 07:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,16 +19,16 @@ msgstr "Slider Ordner"
 msgid "Slider Pane"
 msgstr "Slider Bild"
 
-#: ./ftw/slider/browser/slider.py:45
+#: ./ftw/slider/browser/slider.py:51
 msgid "There is already a slider pane in this context"
 msgstr "Es kann jeweils nur ein Slider Ordner erstellt werden"
 
 #. Default: "It's not possible to add a link and an external url at the same time"
-#: ./ftw/slider/contents/pane.py:44
+#: ./ftw/slider/contents/pane.py:50
 msgid "error_message_links"
 msgstr "Es ist nicht möglich, gleichzeitig einen Link und eine externe URL anzugeben."
 
-#: ./ftw/slider/contents/pane.py:29
+#: ./ftw/slider/contents/pane.py:34
 msgid "help_link"
 msgstr ""
 
@@ -37,22 +37,22 @@ msgstr ""
 msgid "help_slicksettings"
 msgstr "Ändern mit Vorsicht! Hier können Optionen für das JavaScript der Diashow definiert werden. Mögliche Optionen: <a href=\"https://github.com/kenwheeler/slick/#options\">github.com/kenwheeler/slick/#options</a> <br />Läuft alles Schief, Standard verwenden: {\"autoplay\": true, \"autoplaySpeed\": 3000}"
 
-#: ./ftw/slider/contents/pane.py:19
+#: ./ftw/slider/contents/pane.py:21
 msgid "help_text"
 msgstr ""
 
 #. Default: "External URL"
-#: ./ftw/slider/contents/pane.py:34
+#: ./ftw/slider/contents/pane.py:40
 msgid "label_external_url"
 msgstr "Externe URL"
 
 #. Default: "Image"
-#: ./ftw/slider/contents/pane.py:23
+#: ./ftw/slider/contents/pane.py:27
 msgid "label_image"
 msgstr "Bild"
 
 #. Default: "Link"
-#: ./ftw/slider/contents/pane.py:28
+#: ./ftw/slider/contents/pane.py:33
 msgid "label_link"
 msgstr "Link"
 
@@ -61,9 +61,39 @@ msgstr "Link"
 msgid "label_slicksettings"
 msgstr "Einstellungen für Diashow"
 
+#. Default: "Next"
+#: ./ftw/slider/browser/slider.py:26
+msgid "label_slider_next"
+msgstr "Nächstes"
+
+#. Default: "Pause"
+#: ./ftw/slider/browser/slider.py:24
+msgid "label_slider_pause"
+msgstr "Pause"
+
+#. Default: "Play"
+#: ./ftw/slider/browser/slider.py:22
+msgid "label_slider_play"
+msgstr "Abspielen"
+
+#. Default: "Previous"
+#: ./ftw/slider/browser/slider.py:28
+msgid "label_slider_prev"
+msgstr "Vorheriges"
+
 #. Default: "Text"
-#: ./ftw/slider/contents/pane.py:18
+#: ./ftw/slider/contents/pane.py:20
 msgid "label_text"
 msgstr "Text"
+
+#. Default: "See http://kenwheeler.github.io/slick/"
+#: ./ftw/slider/contents/container.py:22
+msgid "slick_config_description"
+msgstr ""
+
+#. Default: "Configuration"
+#: ./ftw/slider/contents/container.py:21
+msgid "slick_config_label"
+msgstr ""
 
 

--- a/ftw/slider/locales/ftw.slider.pot
+++ b/ftw/slider/locales/ftw.slider.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-02 07:57+0000\n"
+"POT-Creation-Date: 2015-09-28 07:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,16 +22,16 @@ msgstr ""
 msgid "Slider Pane"
 msgstr ""
 
-#: ./ftw/slider/browser/slider.py:45
+#: ./ftw/slider/browser/slider.py:51
 msgid "There is already a slider pane in this context"
 msgstr ""
 
 #. Default: "It's not possible to add a link and an external url at the same time"
-#: ./ftw/slider/contents/pane.py:44
+#: ./ftw/slider/contents/pane.py:50
 msgid "error_message_links"
 msgstr ""
 
-#: ./ftw/slider/contents/pane.py:29
+#: ./ftw/slider/contents/pane.py:34
 msgid "help_link"
 msgstr ""
 
@@ -40,22 +40,22 @@ msgstr ""
 msgid "help_slicksettings"
 msgstr ""
 
-#: ./ftw/slider/contents/pane.py:19
+#: ./ftw/slider/contents/pane.py:21
 msgid "help_text"
 msgstr ""
 
 #. Default: "External URL"
-#: ./ftw/slider/contents/pane.py:34
+#: ./ftw/slider/contents/pane.py:40
 msgid "label_external_url"
 msgstr ""
 
 #. Default: "Image"
-#: ./ftw/slider/contents/pane.py:23
+#: ./ftw/slider/contents/pane.py:27
 msgid "label_image"
 msgstr ""
 
 #. Default: "Link"
-#: ./ftw/slider/contents/pane.py:28
+#: ./ftw/slider/contents/pane.py:33
 msgid "label_link"
 msgstr ""
 
@@ -64,9 +64,39 @@ msgstr ""
 msgid "label_slicksettings"
 msgstr ""
 
+#. Default: "Next"
+#: ./ftw/slider/browser/slider.py:26
+msgid "label_slider_next"
+msgstr ""
+
+#. Default: "Pause"
+#: ./ftw/slider/browser/slider.py:24
+msgid "label_slider_pause"
+msgstr ""
+
+#. Default: "Play"
+#: ./ftw/slider/browser/slider.py:22
+msgid "label_slider_play"
+msgstr ""
+
+#. Default: "Previous"
+#: ./ftw/slider/browser/slider.py:28
+msgid "label_slider_prev"
+msgstr ""
+
 #. Default: "Text"
-#: ./ftw/slider/contents/pane.py:18
+#: ./ftw/slider/contents/pane.py:20
 msgid "label_text"
+msgstr ""
+
+#. Default: "See http://kenwheeler.github.io/slick/"
+#: ./ftw/slider/contents/container.py:22
+msgid "slick_config_description"
+msgstr ""
+
+#. Default: "Configuration"
+#: ./ftw/slider/contents/container.py:21
+msgid "slick_config_label"
 msgstr ""
 
 

--- a/ftw/slider/tests/test_slickconfig.py
+++ b/ftw/slider/tests/test_slickconfig.py
@@ -27,6 +27,11 @@ class TestSliderConfig(TestCase):
 
     @browsing
     def test_slider_adds_slick_config_if_available(self, browser):
+        self.portal.portal_languages.manage_setLanguageSettings(
+            'de',
+            ['de'],
+            setUseCombinedLanguageCodes=False)
+
         container = create(Builder('slider container')
                            .within(self.folder)
                            .having(slick_config=json.dumps({'is_chuck': True}))
@@ -40,8 +45,12 @@ class TestSliderConfig(TestCase):
         browser.login().visit(self.folder)
 
         self.assertEqual(
-            '{"is_chuck": true}',
-            browser.css('#slider-panes').first.get('data-settings'))
+            {u'labels': {u'pause': u'Pause',
+                         u'play': u'Abspielen',
+                         u'prev': u'Vorheriges',
+                         u'next': u'N\xe4chstes'},
+             u'is_chuck': True},
+            json.loads(browser.css('#slider-panes').first.get('data-settings')))
 
 
 class TestSliderConfigValidator(TestCase):


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/611

Depends no https://github.com/4teamwork/ftw.sliderblock/pull/19

Extend slider with ```labels``` config for defining labels in action
button such as next, previous, play or pause.