### PR TITLE
Update slider initialisation in listing block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- Add compatibility for ftw.slider using new initialisation syntax.
+  [Kevin Bieri]
+
 - Add compatibility for Plone sites not using ftw.theming.
   Attention: These styling changes are not backwards compatible with exising Plone sites using ftw.theming.
   [Kevin Bieri]

--- a/ftw/slider/browser/listingblock_slider.py
+++ b/ftw/slider/browser/listingblock_slider.py
@@ -10,7 +10,7 @@ class ListingBlockSlider(listingblock_gallery_view.ListingBlockGalleryView):
         if field:
             settings = field.get(self.context)
         return """jQuery(function($) {
-                    $('#uid_%(uid)s .sliderGallery').slick(%(settings)s);
+                    new Slider('#uid_%(uid)s .sliderGallery', %(settings)s);
                   });""" % {
                       'uid': self.context.UID(),
                       'settings': settings,


### PR DESCRIPTION
According to https://github.com/4teamwork/ftw.slider/commit/3baed8689f3bf7e7be32778849962491780f1d22
the new syntax for slider initialisation uses `new Slider()` instead of `$().slick()`.