### PR TITLE
Use image cropping for sliderblock images to keep from breaking the layout with different image ratios.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- Use image cropping for sliderblock images to keep the ratio for different images.
+  [Kevin Bieri]
+
 - Add compatibility for ftw.slider using new initialisation syntax.
   [Kevin Bieri]
 

--- a/ftw/slider/browser/listingblock_slider.pt
+++ b/ftw/slider/browser/listingblock_slider.pt
@@ -12,7 +12,7 @@
           <div class="imgTitle">
             <h3 tal:content="img/Title" />
           </div>
-          <img tal:replace="structure img/@@images/image/sliderblock" />
+          <img tal:replace="structure python: view.get_image_tag(img)" />
           <div class="imgDescription"
                tal:define="img_nr python: repeat['img'].index + 1;
                            img_len python: len(imgs)">

--- a/ftw/slider/browser/listingblock_slider.py
+++ b/ftw/slider/browser/listingblock_slider.py
@@ -15,3 +15,7 @@ class ListingBlockSlider(listingblock_gallery_view.ListingBlockGalleryView):
                       'uid': self.context.UID(),
                       'settings': settings,
                   }
+
+    def get_image_tag(self, img):
+        scaler = img.restrictedTraverse('@@images')
+        return scaler.scale('image', scale='sliderblock', direction='down')


### PR DESCRIPTION
https://extranet.4teamwork.ch/support/0314-support-www.bgbern.ch-burgergemeinde-bern/0314-tracker-neugestaltung-website-burgergemeinde-bern/280