### PR TITLE
Fix icon for simplelayout diashow action.

### DIFF
--- a/ftw/slider/browser/resources/slider.css
+++ b/ftw/slider/browser/resources/slider.css
@@ -143,3 +143,9 @@
 .arrowsOnHover:hover > button {
   display: block;
 }
+
+li.slAction > a.layout_dummy-dummy-slider {
+  background-image: url(++resource++ftw.slider/slider_block.png);
+  background-repeat: no-repeat;
+  background-position: center center;
+}


### PR DESCRIPTION
Closes https://extranet.4teamwork.ch/support/0314-support-www.bgbern.ch-burgergemeinde-bern/0314-tracker-neugestaltung-website-burgergemeinde-bern/282

During rewrite for ftw.theming here: https://github.com/4teamwork/ftw.slider/pull/55.
The diashow icon for the simplelayout action has been accidentally removed.

![bildschirmfoto 2016-04-07 um 09 21 22](https://cloud.githubusercontent.com/assets/1637820/14343646/a39542b2-fca2-11e5-88fb-a12908984b8d.png)