### PR TITLE
Fix UnicodeDecodeError.

### DIFF
--- a/ftw/slider/browser/listingblock_slider.pt
+++ b/ftw/slider/browser/listingblock_slider.pt
@@ -12,7 +12,9 @@
           <div class="imgTitle">
             <h3 tal:content="img/Title" />
           </div>
-          <img tal:replace="structure python: view.get_image_tag(img)" />
+          <tal:block tal:define="image_tag python: view.get_image_tag(img)">
+              <img tal:condition="image_tag" tal:replace="structure image_tag" />
+          </tal:block>
           <div class="imgDescription"
                tal:define="img_nr python: repeat['img'].index + 1;
                            img_len python: len(imgs)">

--- a/ftw/slider/browser/listingblock_slider.py
+++ b/ftw/slider/browser/listingblock_slider.py
@@ -18,4 +18,7 @@ class ListingBlockSlider(listingblock_gallery_view.ListingBlockGalleryView):
 
     def get_image_tag(self, img):
         scaler = img.restrictedTraverse('@@images')
-        return scaler.scale('image', scale='sliderblock', direction='down')
+        scale = scaler.scale('image', scale='sliderblock', direction='down')
+        if not scale:
+            return ''
+        return scale.tag()

--- a/ftw/slider/testing.py
+++ b/ftw/slider/testing.py
@@ -10,6 +10,7 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import applyProfile
 from plone.app.testing import login
 from zope.configuration import xmlconfig
+from plone.testing import z2
 
 
 class SliderLayer(PloneSandboxLayer):
@@ -25,10 +26,15 @@ class SliderLayer(PloneSandboxLayer):
             '</configure>',
             context=configurationContext)
 
+        z2.installProduct(app, 'ftw.contentpage')
+
     def setUpPloneSite(self, portal):
         login(portal, TEST_USER_NAME)
         # Install into Plone site using portal_setup
         applyProfile(portal, 'ftw.slider:default')
+
+        # Install "ftw.contentpage"
+        applyProfile(portal, 'ftw.contentpage:default')
 
 
 SLIDER_TAGS_FIXTURE = SliderLayer()

--- a/ftw/slider/tests/__init__.py
+++ b/ftw/slider/tests/__init__.py
@@ -1,0 +1,18 @@
+import transaction
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import setRoles
+from unittest2 import TestCase
+
+from ftw.slider.testing import SLIDER_FUNCTIONAL_TESTING
+
+
+class FunctionalTestCase(TestCase):
+    layer = SLIDER_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+    def grant(self, *roles):
+        setRoles(self.portal, TEST_USER_ID, list(roles))
+        transaction.commit()

--- a/ftw/slider/tests/builders.py
+++ b/ftw/slider/tests/builders.py
@@ -1,6 +1,7 @@
 from StringIO import StringIO
 from ftw.builder import builder_registry
 from ftw.builder.dexterity import DexterityBuilder
+import ftw.contentpage.tests.builders
 
 
 class SliderContainerBuilder(DexterityBuilder):

--- a/ftw/slider/tests/test_listingblock.py
+++ b/ftw/slider/tests/test_listingblock.py
@@ -1,0 +1,34 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.slider.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+
+
+class TestListingBlockSliderView(FunctionalTestCase):
+
+    @browsing
+    def test_listingblock_slider_view_umlauts(self, browser):
+        """
+        This test makes sure that activating the slider view on a listing block
+        containing files having umlauts in their file name does not result in
+        a `UnicodeDecodeError`.
+        """
+        self.grant('Manager')
+        page = create(Builder('content page'))
+        block = create(Builder('listing block').within(page))
+        create(Builder('image')
+               .titled(u'T\xe4st.png')
+               .with_dummy_content()
+               .within(block))
+
+        browser.login()
+        browser.visit(block, view='block_view-slider')
+
+        self.assertEqual(
+            u'T\xe4st.png',
+            browser.css('img').first.attrib['alt']
+        )
+        self.assertEqual(
+            u'T\xe4st.png',
+            browser.css('img').first.attrib['title']
+        )

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ version = '2.3.4.dev0'
 tests_require = [
     'ftw.testing [splinter]',
     'ftw.builder',
+    'ftw.contentpage',
     'ftw.testbrowser',
     'plone.app.testing',
     'plone.resource',


### PR DESCRIPTION
This error occurs in the slider view of a listing block containing files having umlauts in their file name.

I have not added an entry in the changelog because the bug has not yet been released.

The bug has been introduced in https://github.com/4teamwork/ftw.slider/pull/57