### PR TITLE
Add browser pane redirect view, which behaves like the one from links.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add browser pane redirect view, which behaves like the one from links.
+  [mathias.leimgruber]
 
 
 2.4.1 (2016-07-19)

--- a/ftw/slider/browser/configure.zcml
+++ b/ftw/slider/browser/configure.zcml
@@ -33,5 +33,12 @@
       name="ftw.slider.Container"
       />
 
+  <browser:page
+      for="*"
+      name="sliderpane_view"
+      template="pane.pt"
+      class=".pane.SliderPaneView"
+      permission="zope2.View"
+      />
 
 </configure>

--- a/ftw/slider/browser/pane.pt
+++ b/ftw/slider/browser/pane.pt
@@ -28,7 +28,7 @@
             </tr>
             <tr>
                 <th i18n:translate="label_text">Text</th>
-                <td><tal:text condition="context/text" replace=context/text/ouput"></tal:text></td>
+                <td><tal:text condition="context/text" replace="structure context/text/output" /></td>
             </tr>
             <tr>
                 <th i18n:translate="label_link">Link</th>
@@ -40,7 +40,7 @@
             </tr>
             <tr>
                 <th i18n:translate="label_image">Image</th>
-                <td tal:content="context/image" />
+                <td><tal:image replace="structure python:context.restrictedTraverse('@@images').tag('image', scale='preview')" /></td>
             </tr>
         </table>
 

--- a/ftw/slider/browser/pane.pt
+++ b/ftw/slider/browser/pane.pt
@@ -1,0 +1,52 @@
+<html xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      metal:use-macro="context/main_template/macros/master"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="ftw.slider">
+
+<body>
+
+    <metal:header fill-slot="header" i18n:domain="plone">
+        <dl class="portalMessage info"
+            tal:condition="python: checkPermission('Modify portal content', context)">
+            <dt i18n:translate="">Info</dt>
+            <dd i18n:translate="message_permissions_blocking_link_redirect">
+              You see this page because you have permission to edit this link.
+              Others will be immediately redirected to the link's target URL.
+            </dd>
+        </dl>
+    </metal:header>
+
+    <metal:content-core fill-slot="content-core">
+        <metal:block define-macro="content-core">
+
+
+        <table class="listing">
+            <tr>
+                <th i18n:translate="label_title">Title</th>
+                <td tal:content="context/Title" />
+            </tr>
+            <tr>
+                <th i18n:translate="label_text">Text</th>
+                <td><tal:text condition="context/text" replace=context/text/ouput"></tal:text></td>
+            </tr>
+            <tr>
+                <th i18n:translate="label_link">Link</th>
+                <td tal:content="context/link" />
+            </tr>
+            <tr>
+                <th i18n:translate="label_external_url">External URL</th>
+                <td tal:content="context/external_url" />
+            </tr>
+            <tr>
+                <th i18n:translate="label_image">Image</th>
+                <td tal:content="context/image" />
+            </tr>
+        </table>
+
+        </metal:block>
+    </metal:content-core>
+
+</body>
+</html>
+

--- a/ftw/slider/browser/pane.py
+++ b/ftw/slider/browser/pane.py
@@ -1,0 +1,36 @@
+from plone import api
+from Products.Five.browser import BrowserView
+
+
+class SliderPaneView(BrowserView):
+
+    def __call__(self):
+        redirect_url = self.get_redirect_url()
+        if redirect_url:
+            return self.request.RESPONSE.redirect(redirect_url)
+        else:
+            return super(SliderPaneView, self).__call__()
+
+    def get_redirect_url(self):
+        """Redirect view adopted from plone's link_redirect_view.py"""
+
+        can_edit = api.user.has_permission('Modify portal content',
+                                           obj=self.context)
+
+        link = self.get_link()
+        if not can_edit and link:
+            return link
+        else:
+            return ''
+
+    def get_link(self):
+        if self.context.link:
+            portal_path = '/'.join(api.portal.get().getPhysicalPath())
+            path = self.context.link[len(portal_path):]
+            return api.portal.get().absolute_url() + path
+
+        elif self.context.external_url:
+            return self.context.external_url
+
+        else:
+            return ''

--- a/ftw/slider/browser/pane.py
+++ b/ftw/slider/browser/pane.py
@@ -25,9 +25,7 @@ class SliderPaneView(BrowserView):
 
     def get_link(self):
         if self.context.link:
-            portal_path = '/'.join(api.portal.get().getPhysicalPath())
-            path = self.context.link[len(portal_path):]
-            return api.portal.get().absolute_url() + path
+            return api.portal.get().absolute_url() + self.context.link
 
         elif self.context.external_url:
             return self.context.external_url

--- a/ftw/slider/profiles/default/types/ftw.slider.Pane.xml
+++ b/ftw/slider/profiles/default/types/ftw.slider.Pane.xml
@@ -33,10 +33,10 @@
   </property>
 
   <!-- View information -->
-  <property name="default_view">view</property>
+  <property name="default_view">sliderpane_view</property>
   <property name="default_view_fallback">False</property>
   <property name="view_methods">
-    <element value="view"/>
+    <element value="sliderpane_view"/>
   </property>
 
   <!-- Method aliases -->

--- a/ftw/slider/tests/builders.py
+++ b/ftw/slider/tests/builders.py
@@ -1,6 +1,7 @@
-from StringIO import StringIO
 from ftw.builder import builder_registry
 from ftw.builder.dexterity import DexterityBuilder
+from plone.namedfile.file import NamedBlobImage
+from StringIO import StringIO
 import ftw.contentpage.tests.builders
 
 
@@ -18,12 +19,9 @@ class SliderPaneBuilder(DexterityBuilder):
             'GIF89a\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00'
             '\x00!\xf9\x04\x04\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00'
             '\x01\x00\x00\x02\x02D\x01\x00;')
-        dummy_image.filename = 'logo.png'
-        dummy_image.contentType = 'image/png'
-        dummy_image._height = '20px'
-        dummy_image._width = '20px'
 
-        self.arguments["image"] = dummy_image
+        self.arguments["image"] = NamedBlobImage(dummy_image.read(),
+                                                 filename=u"image.gif")
         return self
 
 builder_registry.register('slider pane', SliderPaneBuilder)

--- a/ftw/slider/tests/test_sliderpane_view.py
+++ b/ftw/slider/tests/test_sliderpane_view.py
@@ -1,0 +1,101 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.slider.testing import SLIDER_FUNCTIONAL_TESTING
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import info_messages
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from unittest2 import TestCase
+
+
+class TestSliderPaneView(TestCase):
+
+    layer = SLIDER_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Contributor', 'Manager'])
+        login(self.portal, TEST_USER_NAME)
+
+        self.folder = create(Builder('folder')
+                             .titled(u'Folder'))
+
+        self.container = create(Builder('slider container')
+                                .within(self.folder)
+                                .titled(u'Slider Container'))
+
+    @browsing
+    def test_do_not_redirect_if_there_is_no_link(self, browser):
+        pane = create(Builder('slider pane')
+                      .within(self.container)
+                      .titled(u'Pane 1')
+                      .with_dummy_image())
+
+        browser.login().visit(pane)
+        self.assertEquals(pane.absolute_url(), browser.url)
+
+    @browsing
+    def test_do_not_redirect_external_url_if_user_can_edit(self, browser):
+        pane = create(Builder('slider pane')
+                      .within(self.container)
+                      .titled(u'Pane 1')
+                      .having(external_url=self.portal.absolute_url())
+                      .with_dummy_image())
+
+        browser.login().visit(pane)
+        self.assertEquals(pane.absolute_url(), browser.url)
+
+    @browsing
+    def test_do_not_redirect_internal_url_if_user_can_edit(self, browser):
+        target = create(Builder('folder')
+                        .titled(u'Target folder'))
+
+        pane = create(Builder('slider pane')
+                      .within(self.container)
+                      .titled(u'Pane 1')
+                      .having(link='/'.join(target.getPhysicalPath()))
+                      .with_dummy_image())
+
+        browser.login().visit(pane)
+        self.assertEquals(pane.absolute_url(), browser.url)
+
+    @browsing
+    def test_redirect_internal_url_if_user_cannot_edit(self, browser):
+        target = create(Builder('folder')
+                        .titled(u'Target folder'))
+
+        pane = create(Builder('slider pane')
+                      .within(self.container)
+                      .titled(u'Pane 1')
+                      .having(link='/'.join(target.getPhysicalPath()))
+                      .with_dummy_image())
+
+        browser.visit(pane)
+        self.assertEquals(target.absolute_url(), browser.url)
+
+    @browsing
+    def test_redirect_external_url_if_user_cannot_edit(self, browser):
+        pane = create(Builder('slider pane')
+                      .within(self.container)
+                      .titled(u'Pane 1')
+                      .having(external_url=self.portal.absolute_url())
+                      .with_dummy_image())
+
+        browser.visit(pane)
+        self.assertEquals(self.portal.absolute_url(), browser.url)
+
+    @browsing
+    def test_message_for_user_with_edit_permission(self, browser):
+        pane = create(Builder('slider pane')
+                      .within(self.container)
+                      .titled(u'Pane 1')
+                      .having(external_url=self.portal.absolute_url())
+                      .with_dummy_image())
+
+        browser.login().visit(pane)
+        self.assertEquals("You see this page because you have permission to "
+                          "edit this link. Others will be immediately "
+                          "redirected to the link's target URL.",
+                          info_messages()[0])

--- a/ftw/slider/tests/test_sliderpane_view.py
+++ b/ftw/slider/tests/test_sliderpane_view.py
@@ -52,10 +52,11 @@ class TestSliderPaneView(TestCase):
         target = create(Builder('folder')
                         .titled(u'Target folder'))
 
+        portal_path = '/'.join(self.portal.getPhysicalPath())
         pane = create(Builder('slider pane')
                       .within(self.container)
                       .titled(u'Pane 1')
-                      .having(link='/'.join(target.getPhysicalPath()))
+                      .having(link='/'.join(target.getPhysicalPath())[portal_path:])
                       .with_dummy_image())
 
         browser.login().visit(pane)
@@ -66,10 +67,11 @@ class TestSliderPaneView(TestCase):
         target = create(Builder('folder')
                         .titled(u'Target folder'))
 
+        portal_path = '/'.join(self.portal.getPhysicalPath())
         pane = create(Builder('slider pane')
                       .within(self.container)
                       .titled(u'Pane 1')
-                      .having(link='/'.join(target.getPhysicalPath()))
+                      .having(link='/'.join(target.getPhysicalPath())[portal_path:])
                       .with_dummy_image())
 
         browser.visit(pane)

--- a/ftw/slider/tests/test_sliderpane_view.py
+++ b/ftw/slider/tests/test_sliderpane_view.py
@@ -56,7 +56,7 @@ class TestSliderPaneView(TestCase):
         pane = create(Builder('slider pane')
                       .within(self.container)
                       .titled(u'Pane 1')
-                      .having(link='/'.join(target.getPhysicalPath())[portal_path:])
+                      .having(link='/'.join(target.getPhysicalPath())[len(portal_path):])
                       .with_dummy_image())
 
         browser.login().visit(pane)
@@ -71,7 +71,7 @@ class TestSliderPaneView(TestCase):
         pane = create(Builder('slider pane')
                       .within(self.container)
                       .titled(u'Pane 1')
-                      .having(link='/'.join(target.getPhysicalPath())[portal_path:])
+                      .having(link='/'.join(target.getPhysicalPath())[len(portal_path):])
                       .with_dummy_image())
 
         browser.visit(pane)

--- a/ftw/slider/upgrades/20160721104124_add_new_pane_view/types/ftw.slider.Pane.xml
+++ b/ftw/slider/upgrades/20160721104124_add_new_pane_view/types/ftw.slider.Pane.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<object name="ftw.slider.Pane"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        xmlns:zcml="http://xml.zope.org/namespaces/zcml"
+        i18n:domain="ftw.slider">
+
+  <property name="default_view">sliderpane_view</property>
+  <property name="view_methods">
+    <element value="sliderpane_view"/>
+  </property>
+
+</object>

--- a/ftw/slider/upgrades/20160721104124_add_new_pane_view/upgrade.py
+++ b/ftw/slider/upgrades/20160721104124_add_new_pane_view/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddNewPaneView(UpgradeStep):
+    """Add new pane view.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -6,4 +6,4 @@ extends =
 package-name = ftw.slider
 
 [versions]
-z3c.form = 3.0.5
+


### PR DESCRIPTION
 
This is used for users, which accidentally hit (Search / direct input) the pane itself.