### PR TITLE
Use preconfigured border radius from ftw.theming instead of user-agent style

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix borderradius of slider button.
+  [Kevin Bieri]
 
 
 3.0.0 (2016-10-25)

--- a/ftw/slider/browser/resources/ftwtheming.scss
+++ b/ftw/slider/browser/resources/ftwtheming.scss
@@ -9,6 +9,7 @@
   > button {
     @extend .fa-icon;
     @include auto-text-color($color-content-background);
+    border-radius: $border-radius-primary;
     background-color: $color-content-background;
     min-width: $line-height-base;
     min-height: $line-height-base;


### PR DESCRIPTION
The button in the screenshot would have a border-radius instead.

![screen shot 2016-11-16 at 16 47 54](https://cloud.githubusercontent.com/assets/1637820/20353870/7ae9590a-ac1c-11e6-9bf4-a1ee5391ed2f.png)
