### PR TITLE
Fix spacing of slider folder

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove plone-site selector !These changes are backwards incompatible!. [Kevin Bieri]
 
 
 3.1.1 (2017-01-16)

--- a/ftw/slider/browser/resources/onegovtheme.sass
+++ b/ftw/slider/browser/resources/onegovtheme.sass
@@ -117,15 +117,11 @@ $slider-color: contrast($slider-bg-start, #FFF, #000);
   margin-bottom: 1em;
 }
 
-body.site-platform .sliderPane {
-  margin-bottom: 0;
-}
-
 .sliderImage {
   margin-bottom: 0;
 }
 
-body.site-platform #slider-wrapper .sliderText {
+.portaltype-plone-site #slider-wrapper .sliderText {
   height: auto;
   min-height: 120px;
   bottom: 0;


### PR DESCRIPTION
The `site-platform` selector is too specific. This selector exactly addresses
a plone site named `platfrom`.