### PR TITLE
Remove dependency on ftw.testing[splinter]

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove dependency on ftw.testing[splinter] (has been dropped in ftw.testing). [lgraf]
 
 
 3.1.2 (2017-05-17)

--- a/ftw/slider/testing.py
+++ b/ftw/slider/testing.py
@@ -1,8 +1,8 @@
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
-from ftw.testing import FunctionalSplinterTesting
 from plone.app.testing import applyProfile
+from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import login
 from plone.app.testing import PLONE_FIXTURE
@@ -10,7 +10,7 @@ from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import TEST_USER_NAME
 from zope.configuration import xmlconfig
 import ftw.referencewidget.tests.widgets
-import ftw.slider.tests.builders
+import ftw.slider.tests.builders  # noqa
 
 
 class SliderLayer(PloneSandboxLayer):
@@ -36,7 +36,7 @@ SLIDER_TAGS_FIXTURE = SliderLayer()
 SLIDER_INTEGRATION_TESTING = IntegrationTesting(
     bases=(SLIDER_TAGS_FIXTURE,),
     name="ftw.slider:integration")
-SLIDER_FUNCTIONAL_TESTING = FunctionalSplinterTesting(
+SLIDER_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(SLIDER_TAGS_FIXTURE,
            set_builder_session_factory(functional_session_factory)),
     name="ftw.slider:functional")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 version = '3.1.3.dev0'
 
 tests_require = [
-    'ftw.testing [splinter]',
+    'ftw.testing',
     'ftw.builder',
     'ftw.testbrowser',
     'plone.app.testing',


### PR DESCRIPTION
This removes the dependency on the `ftw.testing[splinter]` extra, which has been [dropped from 
`ftw.testing`](https://github.com/4teamwork/ftw.testing/commit/6eadb49bed08a0b40113d65abf8b302935cb1007).