### PR TITLE
Improve internal link of panes in the slider view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 3.1.3 (unreleased)
 ------------------
 
+- Improve internal link of panes in the slider view. [mbaechtold]
+
 - Remove dependency on ftw.testing[splinter] (has been dropped in ftw.testing). [lgraf]
 
 

--- a/ftw/slider/browser/pane.py
+++ b/ftw/slider/browser/pane.py
@@ -1,3 +1,4 @@
+from ftw.slider.browser import utils
 from plone import api
 from Products.Five.browser import BrowserView
 
@@ -24,14 +25,4 @@ class SliderPaneView(BrowserView):
             return ''
 
     def get_link(self):
-        link = self.context.link
-        if link:
-            return '{0}{1}'.format(
-                api.portal.get().absolute_url(),
-                link.startswith('/') and link or '/' + link)
-
-        elif self.context.external_url:
-            return self.context.external_url
-
-        else:
-            return ''
+        return utils.get_pane_link(self.context)

--- a/ftw/slider/browser/slider.pt
+++ b/ftw/slider/browser/slider.pt
@@ -10,8 +10,7 @@
       <div tal:repeat="pane panes"
            tal:attributes="class python:pane.text and 'sliderPane sliderPaneHasText' or 'sliderPane'">
 
-        <tal:pane tal:define="internal_link string:${portal/absolute_url}${pane/link};
-                              link python: internal_link and pane.link or pane.external_url;">
+        <tal:pane tal:define="link python: view.get_pane_link(pane)">
           <a tal:omit-tag="not:link"
              tal:attributes="href link"
              class="slider-link">

--- a/ftw/slider/browser/slider.py
+++ b/ftw/slider/browser/slider.py
@@ -1,4 +1,5 @@
 from ftw.slider import _
+from ftw.slider.browser import utils
 from plone.dexterity.browser.add import DefaultAddForm, DefaultAddView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
@@ -43,6 +44,9 @@ class SliderView(BrowserView):
         config = json.loads(self.context.slick_config)
         config = self.extend_translations(config)
         return json.dumps(config)
+
+    def get_pane_link(self, pane):
+        return utils.get_pane_link(pane)
 
 
 class ContainerAddForm(DefaultAddForm):

--- a/ftw/slider/browser/utils.py
+++ b/ftw/slider/browser/utils.py
@@ -1,0 +1,15 @@
+from plone import api
+
+
+def get_pane_link(pane):
+    link = pane.link
+    if link:
+        return '{0}{1}'.format(
+            api.portal.get().absolute_url(),
+            link.startswith('/') and link or '/' + link)
+
+    elif pane.external_url:
+        return pane.external_url
+
+    else:
+        return ''

--- a/ftw/slider/tests/test_sliderpane_view.py
+++ b/ftw/slider/tests/test_sliderpane_view.py
@@ -101,3 +101,24 @@ class TestSliderPaneView(TestCase):
                           "edit this link. Others will be immediately "
                           "redirected to the link's target URL.",
                           info_messages()[0])
+
+    @browsing
+    def test_internal_url_on_slider_view(self, browser):
+        target = create(Builder('folder')
+                        .titled(u'Target folder'))
+
+        portal_path = '/'.join(self.portal.getPhysicalPath())
+        create(Builder('slider pane')
+               .within(self.container)
+               .titled(u'Pane 1')
+               .having(link='/'.join(target.getPhysicalPath())[len(portal_path):])
+               .with_dummy_image())
+
+        # The internal links of the panes in the slider view must be of the form
+        # "http://nohost/plone/target-folder" and not only "/target-folder" in order
+        # for the links to work on localhost too.
+        browser.login().visit(self.container, view='slider_view')
+        self.assertEqual(
+            ['http://nohost/plone/target-folder'],
+            [link.attrib['href'] for link in browser.css('.sliderPane a')]
+        )


### PR DESCRIPTION
The internal links of the panes in the slider view must be of the form "http://hostname/path/to/target-folder" and not only "/target-folder" in order for the links to work on localhost too.