### PR TITLE
Fix faulty upgrade step introduced in 2.3.1.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,16 @@ Changelog
 3.1.3 (unreleased)
 ------------------
 
+- Fix faulty upgrade step introduced in 2.3.1.
+
+  Warning: If you upgrade to this version, the behavior
+  `plone.app.content.interfaces.INameFromTitle` will be added to the
+  content type. Remove it if you don't need it. You may also check if you need
+  to add the `plone.app.referenceablebehavior.referenceable.IReferenceable`
+  behavior in your Plone project.
+
+  [mbaechtold]
+
 - Improve internal link of panes in the slider view. [mbaechtold]
 
 - Remove dependency on ftw.testing[splinter] (has been dropped in ftw.testing). [lgraf]

--- a/ftw/slider/upgrades/20151029134948_remove_i_basic_behavior_from_pane/types/ftw.slider.Pane.xml
+++ b/ftw/slider/upgrades/20151029134948_remove_i_basic_behavior_from_pane/types/ftw.slider.Pane.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <object name="ftw.slider.Pane" meta_type="Dexterity FTI" >
 
-  <property name="behaviors">
+  <property name="behaviors" purge="False">
     <element value="plone.app.dexterity.behaviors.metadata.IBasic" remove="True"/>
   </property>
 

--- a/ftw/slider/upgrades/20170824081802_add_i_name_from_title_behavior_to_ftw_slider_pane/types/ftw.slider.Pane.xml
+++ b/ftw/slider/upgrades/20170824081802_add_i_name_from_title_behavior_to_ftw_slider_pane/types/ftw.slider.Pane.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="ftw.slider.Pane">
+
+    <property name="behaviors" purge="False">
+        <element value="plone.app.content.interfaces.INameFromTitle"/>
+    </property>
+
+</object>

--- a/ftw/slider/upgrades/20170824081802_add_i_name_from_title_behavior_to_ftw_slider_pane/upgrade.py
+++ b/ftw/slider/upgrades/20170824081802_add_i_name_from_title_behavior_to_ftw_slider_pane/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddINameFromTitleBehaviorToFtwSliderPane(UpgradeStep):
+    """Add "INameFromTitle" behavior to "ftw.slider.Pane".
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
The upgrade step introduced in https://github.com/4teamwork/ftw.slider/pull/49 seems to purge the existing behaviors.