### PR TITLE
Revert "Splinter has been removed since for versions greater than 1.11.0"

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.1.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove dependency on ftw.testing[splinter] which have already been removed in 3.1.3 but readded in 3.1.4. [elioschmutz]
 
 
 3.1.4 (2018-04-12)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 version = '3.1.5.dev0'
 
 tests_require = [
-    'ftw.testing [splinter] <= 1.11.0',
+    'ftw.testing',
     'ftw.builder',
     'ftw.testbrowser',
     'plone.app.testing',


### PR DESCRIPTION
This reverts commit a0d55b32cc4498e8e8a94ff153993748d22565e7.

ftw.slider does not implement splinter tests. (see #75 )