### PR TITLE
Add "random" config parameter to display the slides in a random sort-order

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,20 @@ ftw.slider block like:
 
     {"canNext":true, "canPrev":true, "arrowsOnHover":false}
 
+Extended Slick configuration
+============================
+
+In addition to the default slick-configuration options you can use the following `ftw.slider` specific custom options
+
+Random
+------
+
+Shuffles the slides on each page reload to display the slides in a random order.
+
+::
+
+    {"random": true}
+
 
 Screenshots
 ===========

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add "random" config parameter to display the slides in a random sort order on each reload. [elioschmutz]
 
 
 3.2.0 (2019-04-18)

--- a/ftw/slider/browser/resources/slider.js
+++ b/ftw/slider/browser/resources/slider.js
@@ -53,6 +53,12 @@
       element.children("button").remove();
     };
 
+    var shuffle = function(){
+      element.find(".sliderPane").sort(function(){
+        return Math.round(Math.random()) - 0.5;
+      }).detach().appendTo(element);
+    };
+
     var checkResponsive = function() {
       var width = $(window).width();
       var responsiveOption = false;
@@ -86,6 +92,10 @@
 
       if(responsiveConfig) {
         $.extend(config, responsiveConfig);
+      }
+
+      if(config.random) {
+        shuffle();
       }
 
       element.slick(config);


### PR DESCRIPTION
Add "random" config parameter to display the slides in a random sort-order on each reload

Order:

![screen2](https://user-images.githubusercontent.com/557005/58180484-7cb48280-7caa-11e9-8645-b1424549ef4e.gif)

Random:
![screen1](https://user-images.githubusercontent.com/557005/58180494-80e0a000-7caa-11e9-919b-14585c9b36b7.gif)

Configuration:
<img width="802" alt="Bildschirmfoto 2019-05-22 um 15 59 18" src="https://user-images.githubusercontent.com/557005/58180555-9a81e780-7caa-11e9-8083-4515f5b7a37f.png">



Closes #89 
Issuer: https://extranet.4teamwork.ch/extern/0202-projekt-edubs-ict-basler-schulen/tracker-edubs/1110