### PR TITLE
Remove referenceablebehavior in plone 5 and make use of interface.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.4.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove plone.app.referenceablebehavior in plone 5. [busykoala]
 
 
 3.4.3 (2020-01-29)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Remove plone.app.referenceablebehavior in plone 5. [busykoala]
+- Implement the IContainer interface for the slider container. [busykoala]
 
 
 3.4.3 (2020-01-29)

--- a/ftw/slider/contents/container.py
+++ b/ftw/slider/contents/container.py
@@ -1,6 +1,6 @@
 from ftw.slider import _
 from ftw.slider.interfaces import IContainer
-from plone.dexterity.content import Container
+from plone.dexterity.content import Container as DxContainer
 from plone.directives.form import Schema
 from zope import schema
 from zope.interface import implements
@@ -33,5 +33,5 @@ class IContainerSchema(Schema):
     )
 
 
-class Topic(Container):
+class Container(DxContainer):
     implements(IContainer)

--- a/ftw/slider/profiles/default_plone5/types/ftw.slider.Container.xml
+++ b/ftw/slider/profiles/default_plone5/types/ftw.slider.Container.xml
@@ -30,7 +30,6 @@
     <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
     <element value="plone.app.content.interfaces.INameFromTitle" />
     <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
-    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     <element zcml:condition="installed plone.multilingualbehavior"
              value="plone.multilingualbehavior.interfaces.IDexterityTranslatable" />
   </property>

--- a/ftw/slider/profiles/default_plone5/types/ftw.slider.Pane.xml
+++ b/ftw/slider/profiles/default_plone5/types/ftw.slider.Pane.xml
@@ -27,7 +27,6 @@
   <!-- enabled behaviors -->
   <property name="behaviors">
     <element value="plone.app.content.interfaces.INameFromTitle" />
-    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     <element zcml:condition="installed plone.multilingualbehavior"
              value="plone.multilingualbehavior.interfaces.IDexterityTranslatable" />
   </property>

--- a/ftw/slider/upgrades/20200527190657_remove_plone_app_referenceablebehavior/types/ftw.slider.Container.xml
+++ b/ftw/slider/upgrades/20200527190657_remove_plone_app_referenceablebehavior/types/ftw.slider.Container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="ftw.slider.Container">
+  <property name="behaviors" purge="False">
+    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" remove="True"/>
+  </property>
+</object>

--- a/ftw/slider/upgrades/20200527190657_remove_plone_app_referenceablebehavior/types/ftw.slider.Pane.xml
+++ b/ftw/slider/upgrades/20200527190657_remove_plone_app_referenceablebehavior/types/ftw.slider.Pane.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="ftw.slider.Pane">
+  <property name="behaviors" purge="False">
+    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" remove="True"/>
+  </property>
+</object>

--- a/ftw/slider/upgrades/20200527190657_remove_plone_app_referenceablebehavior/upgrade.py
+++ b/ftw/slider/upgrades/20200527190657_remove_plone_app_referenceablebehavior/upgrade.py
@@ -1,0 +1,14 @@
+from ftw.upgrade import UpgradeStep
+import pkg_resources
+
+
+IS_PLONE_5 = pkg_resources.get_distribution('Products.CMFPlone').version >= '5'
+
+
+class RemovePloneAppReferenceablebehavior(UpgradeStep):
+    """Remove plone.app.referenceablebehavior.
+    """
+
+    def __call__(self):
+        if IS_PLONE_5:
+            self.install_upgrade_profile()


### PR DESCRIPTION
The first commits remove plone.app.referenceablebehavior in plone 5.
The last commit makes use of the interfaced referenced to in the type so that it is provided by the sliders container.