### PR TITLE
Remove obsolete behaviours in Plone 5

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.4.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove obsolete behaviour in Plone 5 [Nachtalb]
 
 
 3.4.4 (2020-05-28)

--- a/ftw/slider/profiles/default_plone5/types/ftw.slider.Container.xml
+++ b/ftw/slider/profiles/default_plone5/types/ftw.slider.Container.xml
@@ -30,8 +30,6 @@
     <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
     <element value="plone.app.content.interfaces.INameFromTitle" />
     <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
-    <element zcml:condition="installed plone.multilingualbehavior"
-             value="plone.multilingualbehavior.interfaces.IDexterityTranslatable" />
   </property>
 
   <!-- View information -->

--- a/ftw/slider/profiles/default_plone5/types/ftw.slider.Pane.xml
+++ b/ftw/slider/profiles/default_plone5/types/ftw.slider.Pane.xml
@@ -27,8 +27,6 @@
   <!-- enabled behaviors -->
   <property name="behaviors">
     <element value="plone.app.content.interfaces.INameFromTitle" />
-    <element zcml:condition="installed plone.multilingualbehavior"
-             value="plone.multilingualbehavior.interfaces.IDexterityTranslatable" />
   </property>
 
   <!-- View information -->

--- a/ftw/slider/upgrades/20200923144814_remove_obsolete_behaviours/types/ftw.slider.Container.xml
+++ b/ftw/slider/upgrades/20200923144814_remove_obsolete_behaviours/types/ftw.slider.Container.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<object name="ftw.slider.Container"
+  meta_type="Dexterity FTI"
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+  xmlns:zcml="http://xml.zope.org/namespaces/zcml"
+  i18n:domain="ftw.slider" >
+  <!-- enabled behaviors -->
+  <property name="behaviors">
+    <element value="plone.multilingualbehavior.interfaces.IDexterityTranslatable" remove="True" />
+  </property>
+</object>

--- a/ftw/slider/upgrades/20200923144814_remove_obsolete_behaviours/types/ftw.slider.Pane.xml
+++ b/ftw/slider/upgrades/20200923144814_remove_obsolete_behaviours/types/ftw.slider.Pane.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object name="ftw.slider.Pane"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        xmlns:zcml="http://xml.zope.org/namespaces/zcml"
+        i18n:domain="ftw.slider">
+  <property name="behaviors">
+    <element value="plone.multilingualbehavior.interfaces.IDexterityTranslatable" remove="True" />
+  </property>
+</object>

--- a/ftw/slider/upgrades/20200923144814_remove_obsolete_behaviours/upgrade.py
+++ b/ftw/slider/upgrades/20200923144814_remove_obsolete_behaviours/upgrade.py
@@ -1,0 +1,13 @@
+from Products.CMFPlone.utils import getFSVersionTuple
+from ftw.upgrade import UpgradeStep
+
+PLONE5 = getFSVersionTuple() >= (5, 0)
+
+
+class RemoveObsoleteBehaviours(UpgradeStep):
+    """Remove obsolete behaviours.
+    """
+
+    def __call__(self):
+        if PLONE5:
+            self.install_upgrade_profile()


### PR DESCRIPTION
This behaviour is for Plone 4 only. For Plone 5, one can use plone.app.multilingual directly.